### PR TITLE
fix(sayt): prevent TypeError from invalid per_page query parameter

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -78,12 +78,19 @@ if (!function_exists('eaResultSortBy')) {
 if (!function_exists('results_per_page')) {
     function results_per_page(array $options = []): int
     {
-        if (! empty($options['per_page'])) {
-            return $options['per_page'];
+        $allowed = getPaginationLengths();
+        $default = $allowed[0];
+
+        if (isset($options['per_page']) && $options['per_page'] !== '') {
+            $perPage = $options['per_page'];
+        } elseif (request()->filled('per_page')) {
+            $perPage = request('per_page');
+        } else {
+            $perPage = request()->cookie('resultsPerPage', $default);
         }
 
-        return request()->filled('per_page')
-            ? request('per_page', getPaginationLengths()[0])
-            : request()->cookie('resultsPerPage', getPaginationLengths()[0]);
+        $perPage = (int) $perPage;
+
+        return in_array($perPage, $allowed, true) ? $perPage : $default;
     }
 }


### PR DESCRIPTION
## Summary

Fixes a `TypeError` on shop search pages when `per_page` contains invalid or malformed values (e.g. `per_page=12%27` / `12'`).

- Harden `results_per_page()` in `packages/sayt/src/helpers.php` to resolve the value from options, query string, or cookie
- Cast the value to `(int)` before returning
- Validate against `getPaginationLengths()` and fall back to the default page size when the value is not allowed

## Root cause

`results_per_page()` was declared to return `int` but returned raw request/cookie values as strings. A malformed query parameter like `per_page=12'` could not be coerced to an integer, causing:
